### PR TITLE
Fixed File Encoding and PIL Error.

### DIFF
--- a/mgs_zbxicons.py
+++ b/mgs_zbxicons.py
@@ -46,7 +46,7 @@ def generate_icons(resolution, states):
 		for tsize in sizes:
 			if (resolution in tsize) or resolution == 'all':
 				tw,th=tsize.split(',')
-				i = i.resize((int(tw),int(th)), Image.ANTIALIAS)
+				i = i.resize((int(tw),int(th)), Image.Resampling.LANCZOS)
 				iwidth, iheight = i.size
 				i.save('output/'+icon.replace('.png', '_(')+str(iwidth)+').png')
 		i.close()
@@ -66,7 +66,7 @@ def generate_icons(resolution, states):
 				for tsize in sizes:
 					if (resolution in tsize) or resolution == 'all':
 						tw,th=tsize.split(',')
-						i = i.resize((int(tw),int(th)), Image.ANTIALIAS)
+						i = i.resize((int(tw),int(th)), Image.Resampling.LANCZOS)
 						iwidth, iheight = i.size
 						i.save('output/'+icon.replace('.png', '')+'-'+status.replace('.png','_(')+str(iwidth)+').png')
 				i.close()
@@ -76,10 +76,10 @@ def generate_query(engine):
 	if not os.path.exists('sql'):
 	    os.makedirs('sql')
 	if (engine=='mysql'):
-		sqlFile = open('sql/mgs_zbxicons-mysql.sql','w')
+		sqlFile = open('sql/mgs_zbxicons-mysql.sql','w', encoding='utf-8')
 		sqlFile.write("-- Zabbix MgS_Icons (c) Sternadel Michał 2022\n\r")
 	if (engine=='psql'):
-		sqlFile = open('sql/mgs_zbxicons-psql.sql','w')
+		sqlFile = open('sql/mgs_zbxicons-psql.sql','w', encoding='utf-8')
 		sqlFile.write("-- Zabbix MgS_Icons (c) Sternadel Michał 2022\n\r")
 	
 	for icon in os.listdir('output'):


### PR DESCRIPTION
- Fixed File Encoding Error by explicitly specifying UTF-8  [Link to Fix on StackOverflow](https://stackoverflow.com/questions/14630288/unicodeencodeerror-charmap-codec-cant-encode-character-maps-to-undefined)

- Fixed PIL Error by replacing Image.ANTIALIAS with Image.Resampling.LANCZOS [List of Removed Constants with PIL 10.0](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants)

Tested on Windows 11 with Python 3.9, and Zabbix 6.4 with PostgreSQL 15.4 on Docker